### PR TITLE
return true to suppress error thrown from linter

### DIFF
--- a/src/lib/create.js
+++ b/src/lib/create.js
@@ -40,7 +40,7 @@ export default function create() {
   const packageJSONObject = require(packageJSONPath);
   _.extend(packageJSONObject.scripts, {
     test: 'npm run lint && chimp --mocha --path=tests --browser=phantomjs',
-    lint: 'eslint . --ext .jsx,.js',
+    lint: 'eslint . --ext .jsx,.js || true',
     fix: 'eslint . --ext .jsx,.js --fix',
     watch: 'chimp --ddp=http://localhost:3000 --watch --mocha --path=tests',
   });


### PR DESCRIPTION
Reference to open issue #12 

Proposed Changes:
Add `|| true` so that the npm command always exits 0 and doesn't throw the NPM errors when there is a lint failure.