### PR TITLE
removes the unresolved warnings because eslint cannot find meteor mod…

### DIFF
--- a/templates/.eslintrc
+++ b/templates/.eslintrc
@@ -1,3 +1,8 @@
 {
-  "extends": "airbnb"
+  "extends": "airbnb",
+  "rules": {
+    "import/no-unresolved": [
+      2, { "ignore": ["^meteor/"] }
+    ]
+  }
 }


### PR DESCRIPTION
…ules

Reference to #13 

Proposed changes: Add an ignore rule to the unresolved module warning when the module contains `meteor/somemodule`.

Eslint cannot find these modules because they are exported by meteor and not through the project or node_modules.