### PR TITLE
allow rest and spread operators to pass eslint

### DIFF
--- a/templates/.eslintrc
+++ b/templates/.eslintrc
@@ -4,5 +4,11 @@
     "import/no-unresolved": [
       2, { "ignore": ["^meteor/"] }
     ]
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   }
 }


### PR DESCRIPTION
Currently using the spread operator throws a parsing error.