### PR TITLE
fix: change activeLayerIndex to path in AppWrapper component.

### DIFF
--- a/templates/client/imports/components/AppWrapper.jsx
+++ b/templates/client/imports/components/AppWrapper.jsx
@@ -18,7 +18,7 @@ class AppWrapper extends React.Component {
     ParamStore.listen(
       'path',
       ({changedParams}) => {
-        this.setState({activeLayerIndex: changedParams['path']});
+        this.setState({path: changedParams['path']});
       }
     );
   }


### PR DESCRIPTION
Replaces activeLayerIndex with path which fixes a login bug that occurred at 

```
 const isNotAuthorizedPath =
      !loggedIn && !_.includes(PUBLIC_ROUTES, this.state.path);
```

due to this.state.path not being set correctly.